### PR TITLE
Enhancing to include encoding and decoding of github.com/google/uuid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ _testmain.go
 dist/
 cover.html
 cover.out
+
+.idea

--- a/decode.go
+++ b/decode.go
@@ -3,6 +3,7 @@ package httpheader
 import (
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"net/http"
 	"net/textproto"
 	"reflect"
@@ -155,6 +156,15 @@ func fillValues(sv reflect.Value, opts tagOptions, valArr []string) error {
 	}
 	for sv.Kind() == reflect.Ptr {
 		sv = sv.Elem()
+	}
+
+	if sv.Type() == reflect.TypeOf(uuid.UUID{}) {
+		v, err := uuid.Parse(value)
+		if err != nil {
+			return err
+		}
+		sv.Set(reflect.ValueOf(v))
+		return nil
 	}
 
 	switch sv.Kind() {

--- a/decode_test.go
+++ b/decode_test.go
@@ -2,6 +2,7 @@ package httpheader
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	"net/http"
 	"net/textproto"
 	"reflect"
@@ -167,8 +168,10 @@ type fullTypeStruct struct {
 	Time              time.Time
 	TimeUnix          time.Time `header:"Time-Unix,unix"`
 	// Point             *string
-	Args DecodedArgs `header:"Arg"`
-	Foo  simpleStruct
+	Args     DecodedArgs `header:"Arg"`
+	Foo      simpleStruct
+	UUID     uuid.UUID `header:"Uuid"`
+	UUIDZero uuid.UUID `header:"UuidZero"`
 }
 
 func TestDecodeHeader_more_data_type(t *testing.T) {
@@ -206,6 +209,8 @@ func TestDecodeHeader_more_data_type(t *testing.T) {
 		"Arg.1":        []string{"b"},
 		"Arg.2":        []string{"c"},
 		"Foo":          []string{"bar"},
+		"Uuid":         []string{"123e4567-e89b-12d3-a456-426655440000"},
+		"UuidZero":     []string{"00000000-0000-0000-0000-000000000000"},
 	}
 	want := fullTypeStruct{
 		unExport:          "",
@@ -235,8 +240,10 @@ func TestDecodeHeader_more_data_type(t *testing.T) {
 		Time:              timeV,
 		TimeUnix:          timeV,
 		// Point:             stringPoint("foo"),
-		Args: []string{"a", "b", "c"},
-		Foo:  simpleStruct{Foo: "bar"},
+		Args:     []string{"a", "b", "c"},
+		Foo:      simpleStruct{Foo: "bar"},
+		UUID:     uuid.MustParse("123e4567-e89b-12d3-a456-426655440000"),
+		UUIDZero: uuid.MustParse("00000000-0000-0000-0000-000000000000"),
 	}
 	var got fullTypeStruct
 	err := Decode(h, &got)

--- a/encode_test.go
+++ b/encode_test.go
@@ -2,6 +2,7 @@ package httpheader
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	"net/http"
 	"reflect"
 	"testing"
@@ -81,6 +82,8 @@ func TestHeader_types(t *testing.T) {
 				C bool      `header:",int"`
 				D bool      `header:",int"`
 				E http.Header
+				H uuid.UUID
+				I uuid.UUID
 			}{
 				A: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
 				B: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
@@ -90,6 +93,8 @@ func TestHeader_types(t *testing.T) {
 					"F": []string{"f1"},
 					"G": []string{"gg"},
 				},
+				H: uuid.MustParse("00000000-0000-0000-0000-000000000000"),
+				I: uuid.MustParse("12345678-1234-1234-1234-123456789012"),
 			},
 			http.Header{
 				"A": []string{"Sat, 01 Jan 2000 12:34:56 GMT"},
@@ -98,6 +103,8 @@ func TestHeader_types(t *testing.T) {
 				"D": []string{"0"},
 				"F": []string{"f1"},
 				"G": []string{"gg"},
+				"H": []string{"00000000-0000-0000-0000-000000000000"},
+				"I": []string{"12345678-1234-1234-1234-123456789012"},
 			},
 		},
 		{

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mozillazg/go-httpheader
 
 go 1.11
+
+require github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
UUIDs are pretty commonly used within headers, although it is not a default Golang type, it might be worth supporting? If not we will continue to use our own fork. Let me know if you need any other changes to approve 😄 